### PR TITLE
Update code and `README-KANI` to avoid using `Invariant`

### DIFF
--- a/README-KANI.md
+++ b/README-KANI.md
@@ -2,8 +2,8 @@
 
 This fork uses [Kani](https://github.com/model-checking/kani) to verify proof
 harnesses for `BytesMut` methods showing that they maintain a representation
-invariant (a well-formedness condition).  This example shows Kani's `Invariant`
-trait to define `is_valid()` (the representation invariant) and `Arbitrary`
+invariant (a well-formedness condition).  This example shows how to define the
+`is_valid()` method (i.e., the representation invariant) and Kani's `Arbitrary`
 trait to define a `any()` constructor.
 
 ## Dependencies

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -18,8 +18,6 @@ use crate::bytes::Vtable;
 use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 use crate::{Buf, BufMut, Bytes};
-#[cfg(kani)]
-use kani::Invariant;
 
 /// A unique reference to a contiguous slice of memory.
 ///
@@ -1683,9 +1681,8 @@ impl BytesMut {
     }
 }
 
-
 #[cfg(kani)]
-unsafe impl kani::Invariant for BytesMut {
+impl BytesMut {
     fn is_valid(&self) -> bool {
         self.len <= self.cap
             && match self.kind() {
@@ -1694,10 +1691,7 @@ unsafe impl kani::Invariant for BytesMut {
                 _ => false,
             }
     }
-}
 
-#[cfg(kani)]
-impl BytesMut {
     fn is_valid_kind_vec(&self) -> bool {
         assert!(self.kind() == KIND_VEC);
         let vec_ptr = self.ghost.original_vec_ptr.as_ptr();


### PR DESCRIPTION
This PR moves the `is_valid` definition from `impl Invariant for BytesMut` to `impl BytesMut`, following the deprecation of the `Invariant` trait in Kani. All other references to it in other blog posts have already been updated, and another update for the `tokio bytes` blog post will follow.